### PR TITLE
Change the ticker time to 5 seconds

### DIFF
--- a/configmap-puller/cmd/configmap-puller/main.go
+++ b/configmap-puller/cmd/configmap-puller/main.go
@@ -101,7 +101,7 @@ func watchConfigMap(ctx context.Context, clientset *kubernetes.Clientset, name, 
 		return nil, nil, err
 	}
 
-	ticker := time.NewTicker(1 * time.Minute)
+	ticker := time.NewTicker(5 * time.Second)
 
 	errChan := make(chan error)
 	dataChan := make(chan string)
@@ -121,7 +121,7 @@ func watchConfigMap(ctx context.Context, clientset *kubernetes.Clientset, name, 
 
 			case t := <-ticker.C:
 				log.Println("tick at:", t)
-				timeoutCtx, _ := context.WithTimeout(ctx, 10*time.Second)
+				timeoutCtx, _ := context.WithTimeout(ctx, 5*time.Second)
 				cm, err := clientset.CoreV1().ConfigMaps(namespace).Get(timeoutCtx, name, metav1.GetOptions{})
 				if err != nil {
 					errChan <- err


### PR DESCRIPTION
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-1905
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
