### PR TITLE
Revert "[UPSTREAM] Change the ticker time to 5 seconds"

### DIFF
--- a/configmap-puller/cmd/configmap-puller/main.go
+++ b/configmap-puller/cmd/configmap-puller/main.go
@@ -101,7 +101,7 @@ func watchConfigMap(ctx context.Context, clientset *kubernetes.Clientset, name, 
 		return nil, nil, err
 	}
 
-	ticker := time.NewTicker(5 * time.Second)
+	ticker := time.NewTicker(1 * time.Minute)
 
 	errChan := make(chan error)
 	dataChan := make(chan string)
@@ -121,7 +121,7 @@ func watchConfigMap(ctx context.Context, clientset *kubernetes.Clientset, name, 
 
 			case t := <-ticker.C:
 				log.Println("tick at:", t)
-				timeoutCtx, _ := context.WithTimeout(ctx, 5*time.Second)
+				timeoutCtx, _ := context.WithTimeout(ctx, 10*time.Second)
 				cm, err := clientset.CoreV1().ConfigMaps(namespace).Get(timeoutCtx, name, metav1.GetOptions{})
 				if err != nil {
 					errChan <- err


### PR DESCRIPTION
This reverts commit 2bf9b7a2290308049e117c31fbef6cf9ceadcea2 as the upstream cherry-pick was not correctly done. 
https://github.com/opendatahub-io/odh-images/pull/8 is the upstream PR
