### PR TITLE
Reduce time to avoid downtime

### DIFF
--- a/leader-election/main.go
+++ b/leader-election/main.go
@@ -66,9 +66,9 @@ func main() {
 	leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
 		Lock:            lock,
 		ReleaseOnCancel: true,
-		LeaseDuration:   15 * time.Second,
-		RenewDeadline:   10 * time.Second,
-		RetryPeriod:     2 * time.Second,
+		LeaseDuration:   10 * time.Second,
+		RenewDeadline:   6 * time.Second,
+		RetryPeriod:     1 * time.Second,
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: func(ctx context.Context) {
 				atomic.StoreInt32(&leading, 1)


### PR DESCRIPTION
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [X] JIRA link(s): https://issues.redhat.com/browse/RHODS-2440
- [X] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately
——
**Testing Instructions**

1. Install a base version of rhods (tested with quay.io/modh/qe-catalog-source:v190-7).
2. Install a new version with the following image: quay.io/lferrnan/rhods-operator-live-catalog:1.9.9-1-jupyterhub-downtime.
3. The downtime of jupyterhub should be less than 1 minute and the pods of the old replicaset should be killed instantly.

**Update**

Since last build, trying to update from 1.8-14 to my image forces update to 1.9-7 (might be related to replacement in catalog and semantic tagging) I'm now testing it forcing a rollout of jupyterhub.

1. Install quay.io/lferrnan/rhods-operator-live-catalog:1.9.9-1-jupyterhub-downtime
2. Wait to be deployed
3. Force a rollout in jupyterhub and measure the time